### PR TITLE
Fix broken build caching

### DIFF
--- a/handout-files/Makefile
+++ b/handout-files/Makefile
@@ -27,11 +27,13 @@ all: $(OUT)/src/ $(OUT)/tst/
 $(OUT)/src/: $(JAVA_SRC)
 	@ echo "[javac] $@"
 	@ mkdir -p $@
+	@ touch $@
 	@ $(JC) -d $@ -cp $(SRC_JARS) $(JAVA_SRC)
 
 $(OUT)/tst/: $(JAVA_TST) $(OUT)/src
 	@ echo "[javac] $@"
 	@ mkdir -p $@
+	@ touch $@
 	@ $(JC) -d $@ -cp $(TST_JARS):$(OUT)/src $(JAVA_TST)
 
 


### PR DESCRIPTION
Makefiles do caching checks on the left side of the build instruction. In our case, the left side expressions are directories created only once.